### PR TITLE
Enforce backend-controlled dungeon state and dynamic species costs

### DIFF
--- a/backend/migrations/004_add_monster_experience.sql
+++ b/backend/migrations/004_add_monster_experience.sql
@@ -1,0 +1,5 @@
+ALTER TABLE players
+ADD COLUMN monster_experience TEXT DEFAULT '{}';
+
+UPDATE players
+SET monster_experience = COALESCE(monster_experience, '{}');

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -28,6 +28,7 @@ use DungeonCore\Application\UseCases\ResetGameUseCase;
 use DungeonCore\Application\UseCases\UnlockMonsterSpeciesUseCase;
 use DungeonCore\Application\UseCases\GainMonsterExperienceUseCase;
 use DungeonCore\Application\UseCases\GetAvailableMonstersUseCase;
+use DungeonCore\Application\UseCases\UpdateDungeonStatusUseCase;
 use DungeonCore\Application\UseCases\GetGameConstantsUseCase;
 use DungeonCore\Application\UseCases\GetMonsterTypesUseCase;
 use DungeonCore\Application\UseCases\GetMonsterTraitsUseCase;
@@ -52,18 +53,19 @@ $equipmentRepo = new MySQLEquipmentRepository($pdo);
 $dataRepo = new MySQLDataRepository($pdo);
 
 // Services
-$gameLogic = new GameLogic();
+$gameLogic = new GameLogic($dataRepo);
 
 // Use Cases
-$getGameStateUseCase = new GetGameStateUseCase($gameRepo, $dungeonRepo);
+$getGameStateUseCase = new GetGameStateUseCase($gameRepo, $dungeonRepo, $gameLogic);
 $getDungeonStateUseCase = new GetDungeonStateUseCase($gameRepo, $dungeonRepo);
 $placeMonsterUseCase = new PlaceMonsterUseCase($gameRepo, $dungeonRepo, $gameLogic);
 $addRoomUseCase = new AddRoomUseCase($gameRepo, $dungeonRepo);
-$initializeGameUseCase = new InitializeGameUseCase($gameRepo, $dungeonRepo);
-$resetGameUseCase = new ResetGameUseCase($gameRepo, $dungeonRepo);
+$initializeGameUseCase = new InitializeGameUseCase($gameRepo, $dungeonRepo, $gameLogic);
+$resetGameUseCase = new ResetGameUseCase($gameRepo, $dungeonRepo, $gameLogic);
 $unlockMonsterSpeciesUseCase = new UnlockMonsterSpeciesUseCase($gameRepo, $gameLogic);
 $gainMonsterExperienceUseCase = new GainMonsterExperienceUseCase($gameRepo, $gameLogic);
 $getAvailableMonstersUseCase = new GetAvailableMonstersUseCase($gameRepo, $gameLogic);
+$updateDungeonStatusUseCase = new UpdateDungeonStatusUseCase($gameRepo);
 
 // Data Use Cases
 $getGameConstantsUseCase = new GetGameConstantsUseCase($dataRepo);
@@ -80,7 +82,8 @@ $gameController = new GameController(
     $resetGameUseCase,
     $unlockMonsterSpeciesUseCase,
     $gainMonsterExperienceUseCase,
-    $getAvailableMonstersUseCase
+    $getAvailableMonstersUseCase,
+    $updateDungeonStatusUseCase
 );
 $dungeonController = new DungeonController($addRoomUseCase, $getDungeonStateUseCase);
 $dataController = new DataController(
@@ -116,6 +119,7 @@ $app->post('/api/game/reset', [$gameController, 'resetGame']);
 $app->post('/api/game/unlock-species', [$gameController, 'unlockMonsterSpecies']);
 $app->post('/api/game/gain-experience', [$gameController, 'gainMonsterExperience']);
 $app->get('/api/game/available-monsters', [$gameController, 'getAvailableMonsters']);
+$app->post('/api/game/status', [$gameController, 'updateStatus']);
 $app->get('/api/dungeon/state', [$dungeonController, 'getDungeonState']);
 $app->post('/api/dungeon/add-room', [$dungeonController, 'addRoom']);
 

--- a/backend/src/Application/UseCases/AddRoomUseCase.php
+++ b/backend/src/Application/UseCases/AddRoomUseCase.php
@@ -19,6 +19,16 @@ class AddRoomUseCase
             return ['success' => false, 'error' => 'Game not found'];
         }
 
+        if (!$game->canModifyDungeon()) {
+            return [
+                'success' => false,
+                'error' => 'Dungeon must be closed and free of adventurers before building.',
+                'status' => $game->getStatus(),
+                'activeAdventurerParties' => $game->getActivePartyCount(),
+                'canModifyDungeon' => $game->canModifyDungeon()
+            ];
+        }
+
         // Check mana cost
         if (!$game->spendMana($cost)) {
             return ['success' => false, 'error' => 'Insufficient mana'];
@@ -34,7 +44,9 @@ class AddRoomUseCase
             'success' => true,
             'roomId' => $roomId,
             'type' => $roomType,
-            'position' => $position
+            'position' => $position,
+            'status' => $game->getStatus(),
+            'activeAdventurerParties' => $game->getActivePartyCount()
         ];
     }
 }

--- a/backend/src/Application/UseCases/GetAvailableMonstersUseCase.php
+++ b/backend/src/Application/UseCases/GetAvailableMonstersUseCase.php
@@ -20,14 +20,21 @@ class GetAvailableMonstersUseCase
         }
 
         $availableMonsters = [];
+        $perSpecies = [];
         $unlockedSpecies = $game->getUnlockedSpecies();
-        
+
         foreach ($unlockedSpecies as $speciesName) {
             $speciesTotalExp = $game->getSpeciesTotalExperience($speciesName);
             $unlockedTier = $this->gameLogic->calculateUnlockedTier($speciesTotalExp);
-            
+
             $speciesMonsters = $this->gameLogic->getMonstersForSpeciesAndTier($speciesName, $unlockedTier);
             $availableMonsters = array_merge($availableMonsters, $speciesMonsters);
+
+            $perSpecies[$speciesName] = [
+                'experience' => $speciesTotalExp,
+                'unlockedTier' => $unlockedTier,
+                'monsters' => $speciesMonsters
+            ];
         }
 
         // Sort by tier
@@ -37,7 +44,8 @@ class GetAvailableMonstersUseCase
 
         return [
             'success' => true,
-            'monsters' => $availableMonsters
+            'monsters' => $availableMonsters,
+            'species' => $perSpecies
         ];
     }
 }

--- a/backend/src/Application/UseCases/GetDungeonStateUseCase.php
+++ b/backend/src/Application/UseCases/GetDungeonStateUseCase.php
@@ -31,9 +31,14 @@ class GetDungeonStateUseCase
 
         // Structure the data
         $floorsData = [];
+        $deepestFloorNumber = null;
+        foreach ($floors as $floor) {
+            $deepestFloorNumber = max($deepestFloorNumber ?? $floor->getNumber(), $floor->getNumber());
+        }
+
         foreach ($floors as $floor) {
             $rooms = $this->dungeonRepo->getRoomsByFloorId($floor->getId());
-            
+
             $roomsData = [];
             foreach ($rooms as $room) {
                 $roomMonsters = array_filter($monsters, function($monster) use ($room) {
@@ -54,16 +59,17 @@ class GetDungeonStateUseCase
                             'type' => $monster->getType(),
                             'hp' => $monster->getHp(),
                             'maxHp' => $monster->getMaxHp(),
-                            'alive' => $monster->isAlive()
+                            'alive' => $monster->isAlive(),
+                            'isBoss' => $monster->isBoss()
                         ];
                     }, array_values($roomMonsters))
                 ];
             }
-            
+
             $floorsData[] = [
                 'id' => $floor->getId(),
                 'number' => $floor->getNumber(),
-                'isDeepest' => false, // Default for now - would need logic to determine
+                'isDeepest' => $deepestFloorNumber !== null && $floor->getNumber() === $deepestFloorNumber,
                 'rooms' => $roomsData
             ];
         }
@@ -77,7 +83,8 @@ class GetDungeonStateUseCase
                     'hp' => $monster->getHp(),
                     'maxHp' => $monster->getMaxHp(),
                     'roomId' => $monster->getRoomId(),
-                    'alive' => $monster->isAlive()
+                    'alive' => $monster->isAlive(),
+                    'isBoss' => $monster->isBoss()
                 ];
             }, $monsters)
         ];

--- a/backend/src/Application/UseCases/InitializeGameUseCase.php
+++ b/backend/src/Application/UseCases/InitializeGameUseCase.php
@@ -4,12 +4,14 @@ namespace DungeonCore\Application\UseCases;
 
 use DungeonCore\Domain\Repositories\GameRepositoryInterface;
 use DungeonCore\Domain\Repositories\DungeonRepositoryInterface;
+use DungeonCore\Domain\Services\GameLogic;
 
 class InitializeGameUseCase
 {
     public function __construct(
         private GameRepositoryInterface $gameRepo,
-        private DungeonRepositoryInterface $dungeonRepo
+        private DungeonRepositoryInterface $dungeonRepo,
+        private GameLogic $gameLogic
     ) {}
 
     public function execute(string $sessionId): array
@@ -67,6 +69,14 @@ class InitializeGameUseCase
         
         error_log('Final roomsData: ' . json_encode($roomsData));
         
+        $speciesProgress = [];
+        foreach ($game->getSpeciesExperience() as $species => $xp) {
+            $speciesProgress[$species] = [
+                'experience' => $xp,
+                'unlockedTier' => $this->gameLogic->calculateUnlockedTier($xp)
+            ];
+        }
+
         $result = [
             'game' => [
                 'id' => $game->getId(),
@@ -89,6 +99,10 @@ class InitializeGameUseCase
                 'deepCoreBonus' => 0,
                 'unlockedMonsterSpecies' => $game->getUnlockedSpecies(),
                 'speciesExperience' => $game->getSpeciesExperience(),
+                'monsterExperience' => $game->getMonsterExperienceMap(),
+                'activeAdventurerParties' => $game->getActivePartyCount(),
+                'canModifyDungeon' => $game->canModifyDungeon(),
+                'speciesProgress' => $speciesProgress,
                 'log' => [
                     [
                         'message' => 'Welcome to Dungeon Core Simulator v1.2!',

--- a/backend/src/Application/UseCases/PlaceMonsterUseCase.php
+++ b/backend/src/Application/UseCases/PlaceMonsterUseCase.php
@@ -21,14 +21,19 @@ class PlaceMonsterUseCase
             return ['success' => false, 'error' => 'Game not found'];
         }
 
-        // Check if adventurers are in dungeon
-        if ($game->hasActiveAdventurers()) {
-            return ['success' => false, 'error' => 'Cannot place monsters while adventurers are in the dungeon!'];
+        if (!$game->canModifyDungeon()) {
+            return [
+                'success' => false,
+                'error' => 'Dungeon must be closed and free of adventurers before placing monsters.',
+                'status' => $game->getStatus(),
+                'activeAdventurerParties' => $game->getActivePartyCount(),
+                'canModifyDungeon' => $game->canModifyDungeon()
+            ];
         }
 
         // Validate monster type exists and get stats
         $monsterStats = $this->gameLogic->getMonsterStats($monsterType);
-        if (!$monsterStats) {
+        if (empty($monsterStats)) {
             return ['success' => false, 'error' => 'Monster type not found!'];
         }
 
@@ -95,7 +100,8 @@ class PlaceMonsterUseCase
                 'scaledStats' => $scaledStats
             ],
             'costPaid' => $cost,
-            'remainingMana' => $game->getMana()
+            'remainingMana' => $game->getMana(),
+            'canModifyDungeon' => $game->canModifyDungeon()
         ];
     }
 }

--- a/backend/src/Application/UseCases/ResetGameUseCase.php
+++ b/backend/src/Application/UseCases/ResetGameUseCase.php
@@ -4,13 +4,15 @@ namespace DungeonCore\Application\UseCases;
 
 use DungeonCore\Domain\Repositories\GameRepositoryInterface;
 use DungeonCore\Infrastructure\Database\MySQL\MySQLDungeonRepository;
+use DungeonCore\Domain\Services\GameLogic;
 use Exception;
 
 class ResetGameUseCase
 {
     public function __construct(
         private GameRepositoryInterface $gameRepository,
-        private MySQLDungeonRepository $dungeonRepository
+        private MySQLDungeonRepository $dungeonRepository,
+        private GameLogic $gameLogic
     ) {}
 
     public function execute(string $sessionId): array
@@ -41,7 +43,7 @@ class ResetGameUseCase
             error_log("ResetGameUseCase: Player state reset completed");
             
             // Now reinitialize the game with fresh data
-            $initializeUseCase = new InitializeGameUseCase($this->gameRepository, $this->dungeonRepository);
+            $initializeUseCase = new InitializeGameUseCase($this->gameRepository, $this->dungeonRepository, $this->gameLogic);
             $gameData = $initializeUseCase->execute($sessionId);
             
             error_log("ResetGameUseCase: Game reinitialization completed");

--- a/backend/src/Application/UseCases/UnlockMonsterSpeciesUseCase.php
+++ b/backend/src/Application/UseCases/UnlockMonsterSpeciesUseCase.php
@@ -36,18 +36,15 @@ class UnlockMonsterSpeciesUseCase
         $actualCost = $isFirstSpecies ? 0 : $unlockCost;
 
         // Check if player has enough gold (unless it's their first species)
-        if (!$isFirstSpecies && !$game->spendGold($unlockCost)) {
-            return ['success' => false, 'error' => 'Insufficient gold', 'required' => $unlockCost];
-        } elseif ($isFirstSpecies) {
-            // First species is free, no need to spend gold
-        } else {
-            // Spend gold for additional species
-            $game->spendGold($unlockCost);
+        if (!$isFirstSpecies) {
+            if (!$game->spendGold($actualCost)) {
+                return ['success' => false, 'error' => 'Insufficient gold', 'required' => $actualCost];
+            }
         }
 
         // Unlock the species
         $game->unlockSpecies($speciesName);
-        
+
         // Save game state
         $this->gameRepo->save($game);
 
@@ -56,7 +53,9 @@ class UnlockMonsterSpeciesUseCase
             'speciesName' => $speciesName,
             'costPaid' => $actualCost,
             'remainingGold' => $game->getGold(),
-            'isFirstSpecies' => $isFirstSpecies
+            'isFirstSpecies' => $isFirstSpecies,
+            'unlockedSpecies' => $game->getUnlockedSpecies(),
+            'speciesExperience' => $game->getSpeciesExperience()
         ];
     }
 }

--- a/backend/src/Application/UseCases/UpdateDungeonStatusUseCase.php
+++ b/backend/src/Application/UseCases/UpdateDungeonStatusUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DungeonCore\Application\UseCases;
+
+use DungeonCore\Domain\Repositories\GameRepositoryInterface;
+
+class UpdateDungeonStatusUseCase
+{
+    /** @var array<string, string> */
+    private array $allowedStatuses = [
+        'open' => 'Open',
+        'closed' => 'Closed',
+        'closing' => 'Closing',
+        'maintenance' => 'Maintenance'
+    ];
+
+    public function __construct(private GameRepositoryInterface $gameRepo)
+    {
+    }
+
+    public function execute(string $sessionId, string $status): array
+    {
+        $game = $this->gameRepo->findBySessionId($sessionId);
+        if (!$game) {
+            return ['success' => false, 'error' => 'Game not found'];
+        }
+
+        $normalized = strtolower($status);
+        if (!isset($this->allowedStatuses[$normalized])) {
+            return ['success' => false, 'error' => 'Invalid status value'];
+        }
+
+        $targetStatus = $this->allowedStatuses[$normalized];
+        $game->setStatus($targetStatus);
+
+        $this->gameRepo->save($game);
+
+        return [
+            'success' => true,
+            'status' => $game->getStatus(),
+            'activeAdventurerParties' => $game->getActivePartyCount(),
+            'canModifyDungeon' => $game->canModifyDungeon()
+        ];
+    }
+}

--- a/backend/src/Controllers/GameController.php
+++ b/backend/src/Controllers/GameController.php
@@ -9,6 +9,7 @@ use DungeonCore\Application\UseCases\ResetGameUseCase;
 use DungeonCore\Application\UseCases\UnlockMonsterSpeciesUseCase;
 use DungeonCore\Application\UseCases\GainMonsterExperienceUseCase;
 use DungeonCore\Application\UseCases\GetAvailableMonstersUseCase;
+use DungeonCore\Application\UseCases\UpdateDungeonStatusUseCase;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -21,7 +22,8 @@ class GameController
         private ResetGameUseCase $resetGameUseCase,
         private UnlockMonsterSpeciesUseCase $unlockMonsterSpeciesUseCase,
         private GainMonsterExperienceUseCase $gainMonsterExperienceUseCase,
-        private GetAvailableMonstersUseCase $getAvailableMonstersUseCase
+        private GetAvailableMonstersUseCase $getAvailableMonstersUseCase,
+        private UpdateDungeonStatusUseCase $updateDungeonStatusUseCase
     ) {}
 
     public function initialize(Request $request, Response $response): Response
@@ -90,9 +92,23 @@ class GameController
     public function getAvailableMonsters(Request $request, Response $response): Response
     {
         $sessionId = $this->getSessionId($request);
-        
+
         $result = $this->getAvailableMonstersUseCase->execute($sessionId);
-        
+
+        $response->getBody()->write(json_encode($result));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function updateStatus(Request $request, Response $response): Response
+    {
+        $sessionId = $this->getSessionId($request);
+        $data = json_decode($request->getBody()->getContents(), true);
+
+        $result = $this->updateDungeonStatusUseCase->execute(
+            $sessionId,
+            $data['status'] ?? ''
+        );
+
         $response->getBody()->write(json_encode($result));
         return $response->withHeader('Content-Type', 'application/json');
     }

--- a/backend/src/Domain/Entities/Game.php
+++ b/backend/src/Domain/Entities/Game.php
@@ -15,7 +15,9 @@ class Game
         private int $hour,
         private string $status = 'Open',
         private array $unlockedSpecies = [],
-        private array $speciesExperience = []
+        private array $speciesExperience = [],
+        private array $monsterExperience = [],
+        private int $activePartyCount = 0
     ) {}
 
     public function getId(): int { return $this->id; }
@@ -111,16 +113,49 @@ class Game
         $this->speciesExperience[$speciesName] += $experience;
     }
 
-    public function unlockTier(string $speciesName, int $tier): void
+    public function getMonsterExperience(string $monsterName): int
     {
-        // Implementation for tier unlocking if needed
-        // For now, this is a placeholder
+        return $this->monsterExperience[$monsterName] ?? 0;
+    }
+
+    public function addMonsterExperience(string $monsterName, int $experience): int
+    {
+        if (!isset($this->monsterExperience[$monsterName])) {
+            $this->monsterExperience[$monsterName] = 0;
+        }
+
+        $this->monsterExperience[$monsterName] += $experience;
+
+        return $this->monsterExperience[$monsterName];
+    }
+
+    public function getMonsterExperienceMap(): array
+    {
+        return $this->monsterExperience;
+    }
+
+    public function setMonsterExperience(array $experience): void
+    {
+        $this->monsterExperience = $experience;
+    }
+
+    public function setActivePartyCount(int $count): void
+    {
+        $this->activePartyCount = max(0, $count);
+    }
+
+    public function getActivePartyCount(): int
+    {
+        return $this->activePartyCount;
     }
 
     public function hasActiveAdventurers(): bool
     {
-        // For now, return false to allow monster placement
-        // This can be implemented later when adventurer system is added
-        return false;
+        return $this->activePartyCount > 0;
+    }
+
+    public function canModifyDungeon(): bool
+    {
+        return $this->status === 'Closed' && !$this->hasActiveAdventurers();
     }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,7 +10,8 @@ import type {
   GetAvailableMonstersResponse,
   AddRoomRequest,
   AddRoomResponse,
-  InitializeGameResponse
+  InitializeGameResponse,
+  UpdateDungeonStatusResponse
 } from './types';
 import type { ResetGameResponse } from './resetTypes';
 
@@ -100,6 +101,13 @@ class ApiClient {
   async resetGame(): Promise<ResetGameResponse> {
     return this.request<ResetGameResponse>('/game/reset', {
       method: 'POST',
+    });
+  }
+
+  async updateDungeonStatus(status: string): Promise<UpdateDungeonStatusResponse> {
+    return this.request<UpdateDungeonStatusResponse>('/game/status', {
+      method: 'POST',
+      body: JSON.stringify({ status }),
     });
   }
 

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -54,6 +54,11 @@ export const resetGameAPI = async () => {
   return apiClient.resetGame();
 };
 
+// Update dungeon status via backend
+export const updateDungeonStatus = async (status: string) => {
+  return apiClient.updateDungeonStatus(status);
+};
+
 // Game constants from backend (cached)
 export const fetchGameConstantsData = async () => {
   if (gameConstantsCache === null) {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,6 +11,11 @@ export interface GameStateResponse {
     hour: number;
     status: string;
     unlockedMonsterSpecies: string[];
+    speciesExperience: Record<string, number>;
+    monsterExperience: Record<string, number>;
+    activeAdventurerParties: number;
+    canModifyDungeon: boolean;
+    speciesProgress: Record<string, { experience: number; unlockedTier: number }>;
   };
   floors?: Array<{
     id: number;
@@ -20,7 +25,14 @@ export interface GameStateResponse {
       type: 'entrance' | 'normal' | 'boss' | 'core';
       position: number;
       floorNumber: number;
-      monsters: any[];
+      monsters: Array<{
+        id: number;
+        type: string;
+        hp: number;
+        maxHp: number;
+        alive: boolean;
+        isBoss: boolean;
+      }>;
       roomUpgrade: null;
       explored: boolean;
       loot: number;
@@ -57,6 +69,7 @@ export interface DungeonStateResponse {
         hp: number;
         maxHp: number;
         alive: boolean;
+        isBoss: boolean;
       }>;
     }>;
   }>;
@@ -67,6 +80,7 @@ export interface DungeonStateResponse {
     maxHp: number;
     roomId: number;
     alive: boolean;
+    isBoss: boolean;
   }>;
 }
 
@@ -106,6 +120,8 @@ export interface UnlockMonsterSpeciesResponse {
   costPaid?: number;
   remainingGold?: number;
   required?: number;
+  unlockedSpecies?: string[];
+  speciesExperience?: Record<string, number>;
 }
 
 export interface GainMonsterExperienceRequest {
@@ -124,6 +140,8 @@ export interface GainMonsterExperienceResponse {
     species: string;
     tier: number;
   }>;
+  speciesExperience?: Record<string, number>;
+  monsterExperience?: Record<string, number>;
 }
 
 export interface GetAvailableMonstersResponse {
@@ -135,6 +153,23 @@ export interface GetAvailableMonstersResponse {
     attack: number;
     defense: number;
     tier: number;
+    species: string;
+    baseCost: number;
+    traits: string[];
+  }>;
+  species?: Record<string, {
+    experience: number;
+    unlockedTier: number;
+    monsters: Array<{
+      name: string;
+      hp: number;
+      attack: number;
+      defense: number;
+      tier: number;
+      species: string;
+      baseCost: number;
+      traits: string[];
+    }>;
   }>;
 }
 
@@ -151,6 +186,16 @@ export interface AddRoomResponse {
   roomId?: number;
   type?: string;
   position?: number;
+  status?: string;
+  activeAdventurerParties?: number;
+}
+
+export interface UpdateDungeonStatusResponse {
+  success: boolean;
+  error?: string;
+  status?: string;
+  activeAdventurerParties?: number;
+  canModifyDungeon?: boolean;
 }
 
 export interface InitializeGameResponse {
@@ -175,6 +220,10 @@ export interface InitializeGameResponse {
     deepCoreBonus: number;
     unlockedMonsterSpecies: string[];
     speciesExperience: Record<string, number>;
+    monsterExperience: Record<string, number>;
+    activeAdventurerParties: number;
+    canModifyDungeon: boolean;
+    speciesProgress: Record<string, { experience: number; unlockedTier: number }>;
     log: Array<{
       message: string;
       type: string;
@@ -189,7 +238,14 @@ export interface InitializeGameResponse {
       type: 'entrance' | 'normal' | 'boss' | 'core';
       position: number;
       floorNumber: number;
-      monsters: any[];
+      monsters: Array<{
+        id: number;
+        type: string;
+        hp: number;
+        maxHp: number;
+        alive: boolean;
+        isBoss: boolean;
+      }>;
       roomUpgrade: null;
       explored: boolean;
       loot: number;

--- a/frontend/src/components/game/BackendMonsterPlacement.tsx
+++ b/frontend/src/components/game/BackendMonsterPlacement.tsx
@@ -3,15 +3,17 @@ import { useBackendGameStore } from '../../stores/backendGameStore';
 
 export const BackendMonsterPlacement: React.FC = () => {
   const { gameState, selectedMonster, placeMonster, selectMonster } = useBackendGameStore();
-  const [roomId, setRoomId] = useState<number>(1);
+  const [floorNumber, setFloorNumber] = useState<number>(1);
+  const [roomPosition, setRoomPosition] = useState<number>(1);
 
   const handlePlaceMonster = async () => {
     if (!selectedMonster) return;
-    
-    const success = await placeMonster(roomId, selectedMonster);
+
+    const success = await placeMonster(floorNumber, roomPosition, selectedMonster);
     if (success) {
       selectMonster(null);
-      setRoomId(1);
+      setFloorNumber(1);
+      setRoomPosition(1);
     }
   };
 
@@ -27,23 +29,36 @@ export const BackendMonsterPlacement: React.FC = () => {
             Selected Monster: <span className="font-bold text-blue-400">{selectedMonster}</span>
           </div>
           
-          <div>
-            <label className="block text-white mb-2">Room ID:</label>
-            <input
-              type="number"
-              value={roomId}
-              onChange={(e) => setRoomId(parseInt(e.target.value))}
-              className="bg-gray-700 text-white px-3 py-2 rounded"
-              min="1"
-            />
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-white mb-2">Floor Number:</label>
+              <input
+                type="number"
+                value={floorNumber}
+                onChange={(e) => setFloorNumber(parseInt(e.target.value) || 1)}
+                className="bg-gray-700 text-white px-3 py-2 rounded"
+                min="1"
+              />
+            </div>
+            <div>
+              <label className="block text-white mb-2">Room Position:</label>
+              <input
+                type="number"
+                value={roomPosition}
+                onChange={(e) => setRoomPosition(parseInt(e.target.value) || 1)}
+                className="bg-gray-700 text-white px-3 py-2 rounded"
+                min="1"
+              />
+            </div>
           </div>
-          
+
           <div className="flex gap-2">
             <button
               onClick={handlePlaceMonster}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              disabled={!gameState.canModifyDungeon}
+              className={`px-4 py-2 rounded ${gameState.canModifyDungeon ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-gray-700 text-gray-400 cursor-not-allowed'}`}
             >
-              Place Monster
+              {gameState.canModifyDungeon ? 'Place Monster' : 'Close Dungeon to Build'}
             </button>
             <button
               onClick={() => selectMonster(null)}

--- a/frontend/src/components/game/RoomSelector.tsx
+++ b/frontend/src/components/game/RoomSelector.tsx
@@ -34,6 +34,7 @@ export const RoomSelector: React.FC = () => {
   
   // Get current game data from simplified state
   const mana = gameState?.mana || 0;
+  const canBuild = gameState?.canModifyDungeon ?? false;
   const totalFloors = floors.length;
   
   // Calculate the cost for the next room
@@ -96,6 +97,11 @@ export const RoomSelector: React.FC = () => {
   }, [floors, totalFloors, gameConstants]);
 
   const handleAddRoom = async () => {
+    if (!canBuild) {
+      console.warn('Dungeon must be closed and free of adventurers before adding rooms.');
+      return;
+    }
+
     if (mana >= roomCost && gameConstants) {
       try {
         const deepestFloor = floors.find((f: any) => f.isDeepest);
@@ -134,6 +140,7 @@ export const RoomSelector: React.FC = () => {
   };
 
   const canAfford = mana >= roomCost;
+  const canInteract = canAfford && canBuild;
 
   return (
     <div className="bg-gray-800 p-4 rounded-lg">
@@ -144,21 +151,23 @@ export const RoomSelector: React.FC = () => {
           <h4 className="font-semibold text-gray-300 mb-2">Add Room</h4>
           <button
             className={`w-full p-3 rounded border-2 transition-all ${
-              canAfford 
-                ? 'bg-blue-600 hover:bg-blue-700 text-white border-blue-500' 
+              canInteract
+                ? 'bg-blue-600 hover:bg-blue-700 text-white border-blue-500'
                 : 'bg-gray-600 border-gray-500 text-gray-400 cursor-not-allowed'
             }`}
             onClick={handleAddRoom}
-            disabled={!canAfford}
+            disabled={!canInteract}
           >
             <div className="flex justify-between items-center">
               <span className="font-bold">Add New Room</span>
-              <span className={`text-sm font-bold ${canAfford ? 'text-blue-200' : 'text-red-400'}`}>
+              <span className={`text-sm font-bold ${canInteract ? 'text-blue-200' : 'text-red-400'}`}>
                 {roomCost}💎
               </span>
             </div>
             <div className="text-xs mt-1 opacity-90">
-              {displayMessage}
+              {!canBuild
+                ? 'Close the dungeon and wait for adventurers to leave before constructing.'
+                : displayMessage}
             </div>
           </button>
         </div>

--- a/frontend/src/components/layout/ResourceBar.tsx
+++ b/frontend/src/components/layout/ResourceBar.tsx
@@ -6,14 +6,16 @@ interface ResourceBarProps {
 }
 
 export const ResourceBar: React.FC<ResourceBarProps> = ({ gameState }) => {
-  const { 
-    mana, 
-    maxMana, 
-    gold, 
-    souls, 
-    day, 
-    hour, 
-    status 
+  const {
+    mana,
+    maxMana,
+    gold,
+    souls,
+    day,
+    hour,
+    status,
+    activeAdventurerParties,
+    canModifyDungeon
   } = gameState;
 
   const formatTime = (hour: number) => {
@@ -76,6 +78,14 @@ export const ResourceBar: React.FC<ResourceBarProps> = ({ gameState }) => {
             <span className={`font-bold ${getStatusColor(status)}`}>
               {status}
             </span>
+          </div>
+          <div className="flex items-center gap-3 text-gray-300">
+            <span>
+              Adventurer Parties: <span className="font-bold">{activeAdventurerParties}</span>
+            </span>
+            {!canModifyDungeon && (
+              <span className="text-red-400 font-semibold">Building Locked</span>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/stores/speciesStore.ts
+++ b/frontend/src/stores/speciesStore.ts
@@ -4,10 +4,11 @@ import { persist } from 'zustand/middleware';
 interface SpeciesState {
   unlockedSpecies: string[];
   speciesExperience: Record<string, number>;
+  speciesProgress: Record<string, { experience: number; unlockedTier: number }>;
   lastUpdated: number;
-  
+
   // Actions
-  setSpeciesData: (species: string[], experience: Record<string, number>) => void;
+  setSpeciesData: (species: string[], experience: Record<string, number>, progress?: Record<string, { experience: number; unlockedTier: number }>) => void;
   addUnlockedSpecies: (species: string) => void;
   shouldUpdate: (gameStateTimestamp: number) => boolean;
 }
@@ -17,12 +18,14 @@ export const useSpeciesStore = create<SpeciesState>()(
     (set, get) => ({
       unlockedSpecies: [],
       speciesExperience: {},
+      speciesProgress: {},
       lastUpdated: 0,
 
-      setSpeciesData: (species: string[], experience: Record<string, number>) => {
+      setSpeciesData: (species: string[], experience: Record<string, number>, progress?: Record<string, { experience: number; unlockedTier: number }>) => {
         set({
           unlockedSpecies: species,
           speciesExperience: experience,
+          speciesProgress: progress ?? {},
           lastUpdated: Date.now()
         });
       },
@@ -32,6 +35,10 @@ export const useSpeciesStore = create<SpeciesState>()(
         if (!current.unlockedSpecies.includes(species)) {
           set({
             unlockedSpecies: [...current.unlockedSpecies, species],
+            speciesProgress: {
+              ...current.speciesProgress,
+              [species]: current.speciesProgress[species] ?? { experience: 0, unlockedTier: 1 }
+            },
             lastUpdated: Date.now()
           });
         }


### PR DESCRIPTION
**Summary**
* Added persistent monster experience tracking and active adventurer awareness in the domain/entity layer and MySQL repository, ensuring `Game::canModifyDungeon()` gates building actions.
* Refactored `GameLogic` and related use cases to source monster data from the database, compute species progression, and return tier-aware availability.
* Introduced a `UpdateDungeonStatusUseCase` and wired it into the Slim router to let the frontend close/open the dungeon while enforcing backend rules.
* Hardened `AddRoomUseCase` and `PlaceMonsterUseCase` to reject requests when the dungeon is open or adventurers are present.
* Delivered a new migration adding the `monster_experience` column.
* Reworked the frontend store and UI to consume the backend status, block construction when `canModifyDungeon` is false, and surface adventurer counts and species tier progress.
* Updated the monster selector to read unlock pricing from backend constants, enabling species-specific costs.

**Todo / Follow-ups**
* Backfill species tier and monster experience data for existing players if legacy saves exist (no migration logic for legacy rows beyond default). Suggest adding a script or migration if needed.
* Frontend still relies on legacy `useGameStore` for simulation; consider consolidating or removing duplicated state management.
* Adventurer simulation backend is still stubbed (`hasActiveAdventurers` relies on DB count but parties aren’t managed yet). Full adventurer loop implementation remains outstanding.
* UI traits (attack/defense numbers) are static placeholders; integrate real stats if/when backend exposes them.

**Testing Gaps**
* No automated tests cover new backend status transitions or monster placement gating; recommend writing integration tests for `/game/status`, `/dungeon/add-room`, and `/game/place-monster`.
* Need frontend E2E coverage for the closed-dungeon flow (ensure buttons disable and re-enable correctly).
* When adventurer records exist, verify `canModifyDungeon` flips back after parties depart—requires backend simulation tests.

**Open Quirks / Setup Notes**
* `npm run build` succeeds for the frontend.
* Backend still lacks a CLI command for applying migrations; run `backend/run_migration.php` (or your preferred tool) to apply `004_add_monster_experience.sql`.
* No screenshot captured; UI changes revolve around disabling interactions and new status messaging.
* Remember to run the migration before testing so `monster_experience` column exists—otherwise backend saves will fail.

------
https://chatgpt.com/codex/tasks/task_b_68d63147c7c88321a5f51d8db07d726e